### PR TITLE
SimpleSpriteAnimatorを追加

### DIFF
--- a/Runtime/SimpleSpriteAnimator.meta
+++ b/Runtime/SimpleSpriteAnimator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 306ebe46ce12b0d4d99606a9739975f1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SimpleSpriteAnimator/AnimationState.cs
+++ b/Runtime/SimpleSpriteAnimator/AnimationState.cs
@@ -1,0 +1,23 @@
+namespace LightGive.UnityUtil.Runtime
+{
+	/// <summary>
+	/// アニメーションの状態を表すEnum
+	/// </summary>
+	public enum AnimationState
+	{
+		/// <summary>
+		/// 停止中
+		/// </summary>
+		Stopped,
+
+		/// <summary>
+		/// 再生中
+		/// </summary>
+		Playing,
+
+		/// <summary>
+		/// 一時停止中
+		/// </summary>
+		Paused
+	}
+}

--- a/Runtime/SimpleSpriteAnimator/AnimationState.cs.meta
+++ b/Runtime/SimpleSpriteAnimator/AnimationState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5558bd9c403e39446a2353e23cab5b12

--- a/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimationData.cs
+++ b/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimationData.cs
@@ -1,0 +1,18 @@
+﻿using UnityEngine;
+
+namespace LightGive.UnityUtil.Runtime
+{
+    /// <summary>
+    /// スプライトアニメーションに使用するスプライト配列を格納するScriptableObject
+    /// </summary>
+    [CreateAssetMenu(
+        fileName = "SimpleSpriteAnimationData",
+        menuName = "LightGive/SimpleSpriteAnimationData")]
+    public class SimpleSpriteAnimationData : ScriptableObject
+    {
+        /// <summary>
+        /// アニメーションに使用するスプライトの配列
+        /// </summary>
+        [field: SerializeField] public Sprite[] Sprites { get; private set; }
+    }
+}

--- a/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimationData.cs.meta
+++ b/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimationData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b1fe3f64bd6c26f499523719242621c0

--- a/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimator.cs
+++ b/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimator.cs
@@ -103,7 +103,7 @@ namespace LightGive.UnityUtil.Runtime
 		/// </summary>
 		public void Pause()
 		{
-			if (!IsPlaying || IsPaused)
+			if (!IsPlaying)
 			{
 				return;
 			}

--- a/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimator.cs
+++ b/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimator.cs
@@ -9,13 +9,10 @@ namespace LightGive.UnityUtil.Runtime
 	/// </summary>
 	public class SimpleSpriteAnimator : MonoBehaviour
 	{
-		const int InvalidAnimationIndex = -1;
-
 		[SerializeField] SpriteRenderer _spriteRenderer;
 		[SerializeField] SimpleSpriteAnimationData[] _animationDatas;
 		[SerializeField] UpdateMode _updateMode;
 		[SerializeField] int _fps = 60;
-		int _currentAnimationIndex = InvalidAnimationIndex;
 		int _currentSpriteIndex;
 		float _currentTime;
 		float _timePerSprite;
@@ -72,9 +69,10 @@ namespace LightGive.UnityUtil.Runtime
 		}
 
 		/// <summary>
-		/// 指定されたインデックスのアニメーションを再生開始する
+		/// 指定されたインデックスのアニメーションを最初から再生開始する
 		/// </summary>
 		/// <param name="index">再生するアニメーションのインデックス（デフォルト: 0）</param>
+		/// <remarks>既に同じアニメーションが再生中でも最初からリスタートします</remarks>
 		public void Play(int index = 0)
 		{
 			if (!IsValidAnimationIndex(index))
@@ -83,12 +81,8 @@ namespace LightGive.UnityUtil.Runtime
 				return;
 			}
 
-			// 新しいアニメーションに変更する場合のみリセット
-			if (_currentAnimationIndex != index)
-			{
-				SetCurrentAnimation(index);
-			}
-
+			// 常に最初から再生（予測可能）
+			SetCurrentAnimation(index);
 			State = AnimationState.Playing;
 		}
 
@@ -119,13 +113,14 @@ namespace LightGive.UnityUtil.Runtime
 		/// <summary>
 		/// アニメーションを停止し、状態をリセットする
 		/// </summary>
+		/// <remarks>スプライトは非表示にせず、最後のフレームを表示し続けます</remarks>
 		public void Stop()
 		{
 			State = AnimationState.Stopped;
-			_currentAnimationIndex = InvalidAnimationIndex;
 			_currentSpriteIndex = 0;
 			_currentTime = 0f;
 			_currentAnimationData = null;
+			// スプライトは非表示にしない
 		}
 
 		/// <summary>
@@ -178,13 +173,7 @@ namespace LightGive.UnityUtil.Runtime
 
 		void SetCurrentAnimation(int index)
 		{
-			if (!IsValidAnimationIndex(index))
-			{
-				Debug.LogError($"SetCurrentAnimation: 無効なインデックス {index}");
-				return;
-			}
-
-			_currentAnimationIndex = index;
+			// Play()で既にバリデーション済みのため、チェック不要
 			_currentAnimationData = _animationDatas[index];
 			_currentSpriteIndex = 0;
 			_currentTime = 0f;

--- a/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimator.cs
+++ b/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimator.cs
@@ -1,0 +1,206 @@
+﻿using System.Linq;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace LightGive.UnityUtil.Runtime
+{
+	/// <summary>
+	/// スプライトを使用したシンプルなアニメーション
+	/// </summary>
+	public class SimpleSpriteAnimator : MonoBehaviour
+	{
+		const int InvalidAnimationIndex = -1;
+
+		[SerializeField] SpriteRenderer _spriteRenderer;
+		[SerializeField] SimpleSpriteAnimationData[] _animationDatas;
+		[SerializeField] UpdateMode _updateMode;
+		[SerializeField] int _fps = 60;
+		int _currentAnimationIndex = InvalidAnimationIndex;
+		int _currentSpriteIndex;
+		float _currentTime;
+		float _timePerSprite;
+		SimpleSpriteAnimationData _currentAnimationData;
+
+		/// <summary>
+		/// アニメーションの現在の状態
+		/// </summary>
+		public AnimationState State { get; private set; } = AnimationState.Stopped;
+
+		/// <summary>
+		/// アニメーションが再生中かどうか
+		/// </summary>
+		public bool IsPlaying => State == AnimationState.Playing;
+
+		/// <summary>
+		/// アニメーションが一時停止中かどうか
+		/// </summary>
+		public bool IsPaused => State == AnimationState.Paused;
+
+		/// <summary>
+		/// アニメーションが停止中かどうか
+		/// </summary>
+		public bool IsStopped => State == AnimationState.Stopped; 
+
+		void Reset()
+		{
+			TryGetComponent(out _spriteRenderer);
+		}
+
+		void Awake()
+		{
+			Assert.IsNotNull(_spriteRenderer);
+			Assert.IsTrue(_fps > 0);
+			Assert.IsTrue(_animationDatas.Length > 0);
+			Assert.IsTrue(!_animationDatas.Any(x => x == null));
+
+			for (int i = 0; i < _animationDatas.Length; i++)
+			{
+				Assert.IsNotNull(_animationDatas[i].Sprites);
+				Assert.IsTrue(_animationDatas[i].Sprites.Length > 0);
+				Assert.IsTrue(!_animationDatas[i].Sprites.Any(x => x == null));
+			}
+
+			_timePerSprite = 1f / _fps;
+		}
+
+		void Update()
+		{
+			if (_updateMode == UpdateMode.NormalUpdate)
+			{
+				UpdateFrame();
+			}
+		}
+
+		/// <summary>
+		/// 指定されたインデックスのアニメーションを再生開始する
+		/// </summary>
+		/// <param name="index">再生するアニメーションのインデックス（デフォルト: 0）</param>
+		public void Play(int index = 0)
+		{
+			if (!IsValidAnimationIndex(index))
+			{
+				Debug.LogWarning($"無効なアニメーションインデックス: {index}");
+				return;
+			}
+
+			// 新しいアニメーションに変更する場合のみリセット
+			if (_currentAnimationIndex != index)
+			{
+				SetCurrentAnimation(index);
+			}
+
+			State = AnimationState.Playing;
+		}
+
+		/// <summary>
+		/// 一時停止中のアニメーションを再開する
+		/// </summary>
+		public void Resume()
+		{
+			if (!IsPaused)
+			{
+				return;
+			}
+			State = AnimationState.Playing;
+		}
+
+		/// <summary>
+		/// 再生中のアニメーションを一時停止する
+		/// </summary>
+		public void Pause()
+		{
+			if (!IsPlaying || IsPaused)
+			{
+				return;
+			}
+			State = AnimationState.Paused;
+		}
+
+		/// <summary>
+		/// アニメーションを停止し、状態をリセットする
+		/// </summary>
+		public void Stop()
+		{
+			State = AnimationState.Stopped;
+			_currentAnimationIndex = InvalidAnimationIndex;
+			_currentSpriteIndex = 0;
+			_currentTime = 0f;
+			_currentAnimationData = null;
+		}
+
+		/// <summary>
+		/// アニメーションフレームを手動で次に進める
+		/// </summary>
+		public void UpdateFrameManual()
+		{
+			if (!CanUpdateAnimation())
+			{
+				return;
+			}
+
+			var nextIndex = (_currentSpriteIndex + 1) % _currentAnimationData.Sprites.Length;
+			SetCurrentSprite(nextIndex);
+		}
+
+		void UpdateFrame()
+		{
+			if (!CanUpdateAnimation())
+			{
+				return;
+			}
+
+			_currentTime += Time.deltaTime;
+
+			int targetSpriteIndex = Mathf.FloorToInt(_currentTime / _timePerSprite) % _currentAnimationData.Sprites.Length;
+
+			if (targetSpriteIndex != _currentSpriteIndex)
+			{
+				SetCurrentSprite(targetSpriteIndex);
+			}
+		}
+
+		bool CanUpdateAnimation()
+		{
+			return State == AnimationState.Playing && _currentAnimationData != null;
+		}
+
+		bool IsValidAnimationIndex(int index)
+		{
+			return index >= 0 && index < _animationDatas.Length;
+		}
+
+		bool IsValidSpriteIndex(int spriteIndex)
+		{
+			return _currentAnimationData?.Sprites != null &&
+			       spriteIndex >= 0 &&
+			       spriteIndex < _currentAnimationData.Sprites.Length;
+		}
+
+		void SetCurrentAnimation(int index)
+		{
+			if (!IsValidAnimationIndex(index))
+			{
+				Debug.LogError($"SetCurrentAnimation: 無効なインデックス {index}");
+				return;
+			}
+
+			_currentAnimationIndex = index;
+			_currentAnimationData = _animationDatas[index];
+			_currentSpriteIndex = 0;
+			_currentTime = 0f;
+			SetCurrentSprite(0);
+		}
+
+		void SetCurrentSprite(int spriteIndex)
+		{
+			if (!IsValidSpriteIndex(spriteIndex))
+			{
+				Debug.LogError($"SetCurrentSprite: 無効なスプライトインデックス {spriteIndex}");
+				return;
+			}
+
+			_currentSpriteIndex = spriteIndex;
+			_spriteRenderer.sprite = _currentAnimationData.Sprites[spriteIndex];
+		}
+	}
+}

--- a/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimator.cs.meta
+++ b/Runtime/SimpleSpriteAnimator/SimpleSpriteAnimator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0c34446ce8c4fc64e88c3827b51457ca

--- a/Runtime/SimpleSpriteAnimator/UpdateMode.cs
+++ b/Runtime/SimpleSpriteAnimator/UpdateMode.cs
@@ -1,4 +1,4 @@
-﻿namespace LightGive.UnityUtil
+﻿namespace LightGive.UnityUtil.Runtime
 {
     /// <summary>
     /// アニメーションの更新モードを定義するEnum

--- a/Runtime/SimpleSpriteAnimator/UpdateMode.cs
+++ b/Runtime/SimpleSpriteAnimator/UpdateMode.cs
@@ -1,0 +1,18 @@
+﻿namespace LightGive.UnityUtil
+{
+    /// <summary>
+    /// アニメーションの更新モードを定義するEnum
+    /// </summary>
+    public enum UpdateMode
+    {
+        /// <summary>
+        /// 自動更新モード（Update内で自動的にアニメーションフレームを更新）
+        /// </summary>
+        NormalUpdate,
+
+        /// <summary>
+        /// 手動更新モード（UpdateFrameManualメソッドを呼び出してフレームを更新）
+        /// </summary>
+        ManualUpdate
+    }
+}

--- a/Runtime/SimpleSpriteAnimator/UpdateMode.cs.meta
+++ b/Runtime/SimpleSpriteAnimator/UpdateMode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 550dcbe096f1de246874ff486f185c2c


### PR DESCRIPTION
Unityでスプライトアニメーションを簡単に実行できるSimpleSpriteAnimatorコンポーネントを新規実装。
時間ベースの滑らかなアニメーション制御、状態管理、手動/自動更新モード切替などの機能を提供します
 
🚀 使用方法

基本セットアップ

1. GameObjectにSimpleSpriteAnimatorをアタッチ
2. SimpleSpriteAnimationDataアセットを作成（メニュー:LightGive/SimpleSpriteAnimationData）
3. アニメーションデータにSprite配列を設定
4. SimpleSpriteAnimatorのAnimation Datasに設定

コード例
```
// アニメーション再生
animator.Play(0);

// 一時停止
animator.Pause();

// 再開
animator.Resume();

// 停止
animator.Stop();

// 手動更新（ManualUpdateモード時）
animator.UpdateFrameManual();
```
